### PR TITLE
Added setup.py, tweaks for Py 2/3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ In order to use the dictionary, simply clone the repository into your project di
 # Clone the repo
 $ git clone https://github.com/ryansmick/SortedOrderedDict.git
 
+# Or install via pip:
+
+$ pip install git+https://github.com/ryansmick/SortedOrderedDict.git
+
 # In python file, import the dict
 >>> from SortedOrderedDict import SortedOrderedDict
 
@@ -60,7 +64,7 @@ This is the bread and butter of this data structure because it was designed with
 # Iterate dictionary in sorted order
 >>> for key, value in map.iteritems_sorted():
 ...   process()
-  
+
 # Iterate dictionary in reverse sorted order
 >>> for key, value in map.iteritems_sorted(reverse=True):
 ...   process()
@@ -96,7 +100,7 @@ def save(self, save_filepath=None, delim=': ')
 def load(self, filepath, delim=': ', key_trans_func=None, value_trans_func=None, add_to_existing=False)
 ```
 
-Starting with the save function, the definition is fairly straightforward. It includes optional parameters for save_filepath and delim. You can choose to specify these parameters in the constructor so that ```save()``` performs the same action every time, or you can specify parameters in the function call itself. Additionally, if you specify parameters in the constructor, you can override them by specifying them in the function call. 
+Starting with the save function, the definition is fairly straightforward. It includes optional parameters for save_filepath and delim. You can choose to specify these parameters in the constructor so that ```save()``` performs the same action every time, or you can specify parameters in the function call itself. Additionally, if you specify parameters in the constructor, you can override them by specifying them in the function call.
 
 Note: When using an object with the dictionary, it will be saved as a string using the ```str()``` function to convert the object to a string. In order for this to function properly, the object must have an overloaded``` __str__()``` function that should encode the object as a single line string using a different delimiter between member variables than the dictionary delimiter.
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+from setuptools import find_packages, setup
+
+
+setup(name='smickdict',
+      author='Ryan Smick',
+      packages=find_packages())

--- a/smickdict/PersistentDict.py
+++ b/smickdict/PersistentDict.py
@@ -1,7 +1,7 @@
 # PersistentDict.py
 # Implements a class for a Persistent Dictionary that has the ability to save to and load from a YAML file
 
-from SortedOrderedDict import SortedOrderedDict
+from smickdict.SortedOrderedDict import SortedOrderedDict
 
 # Subclass of SortedOrderedDict that has teh ability to save and load to and from a YAML file
 # Additionally, implemented functions to allow use with a context manager (i.e. "with PersistentDict(...) as map")

--- a/smickdict/SortedOrderedDict.py
+++ b/smickdict/SortedOrderedDict.py
@@ -2,10 +2,13 @@
 # Module for a sorted ordered dictionary
 
 import random
-from itertools import zip_longest
+try:
+    from itertools import zip_longest
+except ImportError:
+    from itertools import izip_longest as zip_longest
 
 # Object to represent a dictionary that is ordered by insertion as well as a sorting of the keys
-class SortedOrderedDict:
+class SortedOrderedDict(object):
 	def __init__(self, compare_fn=None):
 		self.root = None
 		self.head = None

--- a/smickdict/__init__.py
+++ b/smickdict/__init__.py
@@ -1,0 +1,2 @@
+from .SortedOrderedDict import SortedOrderedDict
+from .PersistentDict import PersistentDict

--- a/test.py
+++ b/test.py
@@ -1,7 +1,7 @@
 # test.py
 # Test script for SortedorderedDict
 
-from SortedOrderedDict import SortedOrderedDict
+from smickdict.SortedOrderedDict import SortedOrderedDict
 import sys
 import random
 from collections import OrderedDict


### PR DESCRIPTION
Adding setup.py allows for easy installation via pip. Made tweaks to
handle changes in import semantics (and itertools exports) between
python 2 and 3
Switched `SortedOrderedDict` to new-style classing for broader
`super` support on modern py distributions.